### PR TITLE
Add vnc template for OSX

### DIFF
--- a/templates/conn/osxvnc.mustache
+++ b/templates/conn/osxvnc.mustache
@@ -1,0 +1,1 @@
+ssh -f -N -L {{localport}}:{{host}}:{{port}} {{sshuser}}@{{sshhost}} && open vnc://:{{password}}@localhost:{{localport}}


### PR DESCRIPTION
TEMPLATE FOR OSX

When an RSH key is installed, the tunnel is created and the VNC window opens automatically.

With no RSH key, the tunnel will prompt for a password. If correct, the tunnel is created and the vnc window pops up.

User gets a few chances to enter a correct password. Upon success, vnc client appears.

If multiple password attempts fail, the user is drapped back to the command line with error:
 `Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password).`
